### PR TITLE
Fix cdap dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.2.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
     <junit.version>4.11</junit.version>
     <guava.version>13.0.1</guava.version>
     <commons-jexl.version>3.0</commons-jexl.version>


### PR DESCRIPTION
We bumped cdap to 6.0.0-SNAPSHOT [here](https://github.com/caskdata/cdap/pull/10814)

Updating cdap dependency