### PR TITLE
bump cdap version to resolve vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.1</cdap.version>
+    <cdap.version>6.8.0</cdap.version>
     <junit.version>4.11</junit.version>
     <guava.version>13.0.1</guava.version>
     <commons-jexl.version>3.0</commons-jexl.version>
@@ -294,7 +294,7 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,9.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,10 @@
           <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-explore-jdbc</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
There exists a transitive dependency on log4j version 1.2.17 in test scope due to cdap-unit-test.
```
[INFO] io.cdap.plugin:condition-plugins:jar:1.12.0-SNAPSHOT
[INFO] \- io.cdap.cdap:cdap-unit-test:jar:6.1.1:test
[INFO]    \- io.cdap.cdap:cdap-app-fabric:jar:6.1.1:test
[INFO]       \- org.apache.hadoop:hadoop-yarn-client:jar:2.3.0:test
[INFO]          \- log4j:log4j:jar:1.2.17:test
```
### Changes:
- Updated cdap to latest version

Maven build succeeded.